### PR TITLE
Refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,85 +1,27 @@
-# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
-language: c
 sudo: false
+language: generic
 
+# Caching so the next build will be fast too.
 cache:
   directories:
-    - $HOME/.cabsnap
-    - $HOME/.cabal/packages
+  - $HOME/.stack
 
-before_cache:
-  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
-  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+# Ensure necessary system libraries are present
+addons:
+  apt:
+    packages:
+      - libgmp-dev
 
-matrix:
-  include:
-    - env: CABALVER=1.18 GHCVER=7.8.4
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
-    - env: CABALVER=head GHCVER=head
-      compiler: ": #GHC head"
-      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
-
-  allow_failures:
-    - env: CABALVER=head GHCVER=head
-
+# Download and unpack the stack executable
 before_install:
- - unset CC
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
+# Build dependencies
 install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
-   then
-     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
-          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
-   fi
- - travis_retry cabal update -v
- - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --max-backjumps=-1 --enable-benchmarks --dry -v > installplan.txt
- - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+- stack --no-terminal --install-ghc test --only-dependencies
 
-# check whether current requested install-plan matches cached package-db snapshot
- - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
-   then
-     echo "cabal build-cache HIT";
-     rm -rfv .ghc;
-     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
-     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
-   else
-     echo "cabal build-cache MISS";
-     rm -rf $HOME/.cabsnap;
-     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --max-backjumps=-1 --enable-benchmarks;
-   fi
-
-# snapshot package-db on cache miss
- - if [ ! -d $HOME/.cabsnap ];
-   then
-      echo "snapshotting package-db to build-cache";
-      mkdir $HOME/.cabsnap;
-      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
-      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
-   fi
-
-# Here starts the actual work to be performed for the package under test;
-# any command which exits with a non-zero exit code causes the build to fail.
+# Build the package and its tests and run the tests
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test --show-details=always --test-option=--color
- - cabal check
- - cabal sdist   # tests that a source-distribution can be generated
-
-# Check that the resulting source distribution can be built & installed.
-# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
-# `cabal install --force-reinstalls dist/*-*.tar.gz`
- - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
-
-# EOF
+- stack --no-terminal test

--- a/app/Dm.hs
+++ b/app/Dm.hs
@@ -51,12 +51,12 @@ dockmaster path local command args = do
   eWd <- getWorkDir path
   either dmcError dmExec eWd where
     dmcError WorkDirNotFound     = errorExit "Could not resolve dockmaster working directory."
-    dmcError (DecodingError err) = echo_err "Failed to parse dm configuration.\n" >> errorExit err
+    dmcError (DecodingError err) = echo_err "Failed to parse dm configuration." >> errorExit err
     dmExec wd = sub $ do
       cd wd
       dmYml <- dockmasterYml
       case dmYml of
-        Left err    -> echo_err "Failed to parse dockmaster.yml:\n" >> errorExit err
+        Left err    -> echo_err "Failed to parse dockmaster.yml." >> errorExit err
         Right dmYml -> do
           prepareEnv dmYml
           let hookwrap = hookWrap' dmYml command $ dockercompose dmYml $ command : args

--- a/app/Dm.hs
+++ b/app/Dm.hs
@@ -9,75 +9,70 @@ import Options.Applicative
 
 import Prelude hiding (FilePath)
 import Data.Monoid ((<>))
+import Control.Monad (join)
 import Options.Utils (text, filePathOption)
 import qualified Data.Text as T
 
 default (T.Text)
 
--- | Datatype to hold cli options/arguments
-data Dm = Dm
-  { dmCompositionDir :: FilePath
-  , dmVerbose        :: Bool
-  , dmLocal          :: Bool
-  , dmDcCommand      :: T.Text
-  , dmDcOpts         :: [T.Text]
-  } deriving (Eq,Show)
-
 -- | Main runtime
--- Retrieves possible DOCKMASTER_COMPOSITION env variable for use as
+--
+-- Retrieves possible @DOCKMASTER_COMPOSITION@ env variable for use as
 -- default composition, then defers to cli parser & shelly runtime
 main :: IO ()
 main = do
   envCompDir <- shelly $ get_env "DOCKMASTER_COMPOSITION"
   let defaultCompDir = maybe "." T.unpack envCompDir
-   in execParser (opts defaultCompDir) >>= execShelly
+  join . execParser $
+    info (helper <*> parser defaultCompDir)
+    (  fullDesc
+    <> progDesc "Orchestrate your docker-compose"
+    <> header "dm - yaml loving docker compose orchestration"
+    )
+
+-- | Parse CLI opts/args into arguments for 'execDm'
+parser :: String -> Parser (IO ())
+parser defaultCompDir =
+  execDm
+    <$> filePathOption
+        ( long "composition"
+        <> short 'c'
+        <> metavar "PATH"
+        <> showDefault
+        <> value defaultCompDir
+        <> help "Composition directory. Note this can be relative to any directories specified in global config." )
+    <*> switch
+        ( long "verbose"
+        <> short 'v'
+        <> help "Verbose output.")
+    <*> switch
+        ( long "local"
+        <> short 'l'
+        <> help "Execute without connecting to configured docker machine." )
+    <*> argument text
+        ( metavar "COMMAND"
+        <> help "Command to forward to docker-compose.")
+    <*> many (argument text
+        ( metavar "ARGS"
+        <> help "Any arguments/options to forward to docker-compose COMMAND."))
 
 -- | Shelly execution
 --
--- Accepts 'Dm' instance and forwards to 'dm' function
-execShelly :: Dm -> IO ()
-execShelly (Dm c v l command optargs) = shelly
+-- Sets up shelly environment and forwards to 'dockmaster' function
+execDm :: FilePath -- ^ Composition
+       -> Bool     -- ^ Verbosity flag
+       -> Bool     -- ^ Local-only flag
+       -> T.Text   -- ^ Command
+       -> [T.Text] -- ^ Opts/args for Command
+       -> IO ()
+execDm c v l command optargs = shelly
   $ escaping False
   $ subVerbosity v
   $ dockmaster c l command optargs
 
 -- | Accepts a verbosity setting for the subshell
+--
 -- Propogates verbosity to printing options for commands, stdout, stderr
 subVerbosity :: Bool -> Sh a -> Sh a
 subVerbosity v =
   print_stdout v . print_stderr v . print_commands v
-
--- | Parser for 'Dm' opts/args.
--- Takes a string argument as the default composition value
-parser :: String -> Parser Dm
-parser defaultCompDir = Dm
-  <$> filePathOption
-      ( long "composition"
-      <> short 'c'
-      <> metavar "PATH"
-      <> showDefault
-      <> value defaultCompDir
-      <> help "Composition directory. Note this can be relative to any directories specified in global config." )
-  <*> switch
-      ( long "verbose"
-      <> short 'v'
-      <> help "Verbose output.")
-  <*> switch
-      ( long "local"
-      <> short 'l'
-      <> help "Execute without connecting to configured docker machine." )
-  <*> argument text
-      ( metavar "COMMAND"
-      <> help "Command to forward to docker-compose.")
-  <*> many (argument text
-      ( metavar "ARGS"
-      <> help "Any arguments/options to forward to docker-compose COMMAND."))
-
--- | Generate 'ParserInfo' 'Dm'.
--- Takes a string argument as the default composition value
-opts :: String -> ParserInfo Dm
-opts defaultCompDir = info (helper <*> parser defaultCompDir)
-  (  fullDesc
-  <> progDesc "Orchestrate your docker-compose"
-  <> header "dm - yaml loving docker compose orchestration"
-  )

--- a/app/Dm.hs
+++ b/app/Dm.hs
@@ -49,9 +49,10 @@ execShelly opts = shelly
 dockmaster :: FilePath -> Bool -> T.Text -> [T.Text] -> Sh ()
 dockmaster path local command args = do
   eWd <- getWorkDir path
-  case eWd of
-    Left err -> errorExit err
-    Right wd -> sub $ do
+  either dmcError dmExec eWd where
+    dmcError WorkDirNotFound     = errorExit "Could not resolve dockmaster working directory."
+    dmcError (DecodingError err) = echo_err "Failed to parse dm configuration.\n" >> errorExit err
+    dmExec wd = sub $ do
       cd wd
       dmYml <- dockmasterYml
       case dmYml of

--- a/src/Dockmaster.hs
+++ b/src/Dockmaster.hs
@@ -6,15 +6,10 @@ Maintainer  : sam.chong.tay@gmail.com
 Stability   : experimental
 Portability : POSIX
 -}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ExtendedDefaultRules #-}
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 module Dockmaster
   (
-  -- * Runtime execution
-    dm
   -- * dockmaster.yml
-  , module Dockmaster.Types
+    module Dockmaster.Types
   , module Dockmaster.Parser
   , module Dockmaster.Compose
   -- * config.yml
@@ -22,39 +17,8 @@ module Dockmaster
   , module Dockmaster.Config.Parser
   ) where
 
--- Base modules
-import Data.Either
-import Data.Monoid ((<>))
-import Control.Monad
-
--- Local modules
 import Dockmaster.Types
-import Dockmaster.Config.Types
 import Dockmaster.Parser
-import Dockmaster.Config.Parser
 import Dockmaster.Compose
-
--- External modules
-import Shelly
-import Prelude hiding (FilePath)
-import qualified Data.Text as T
-default (T.Text)
-
--- | Runs @docker-compose@ commands against resolved composition locations
--- See usage docs for more info. Tries to find a @dockmaster.yml@ file based on
--- the initial path argument
-dm :: FilePath -> T.Text -> [T.Text] -> Sh ()
-dm path command args = do
-  eWd <- getWorkDir path
-  case eWd of
-    Left err -> errorExit err
-    Right wd -> sub $ do
-      cd wd
-      dmYml <- dockmasterYml
-      case dmYml of
-        Left err    -> echo_err "Failed to parse dockmaster.yml:\n" >> errorExit err
-        Right dmYml -> do
-          prepareEnv dmYml
-          let targets = map targetName $ dmTargets dmYml -- just grabbing machine name
-          forM_ targets $ \m -> dockermachine m $ do
-            hookWrap' dmYml command $ dockercompose dmYml $ command : args
+import Dockmaster.Config.Types
+import Dockmaster.Config.Parser

--- a/src/Dockmaster.hs
+++ b/src/Dockmaster.hs
@@ -34,10 +34,14 @@ import Control.Monad (forM_)
 import qualified Data.Text as T
 default (T.Text)
 
--- | Runs @docker-compose@ commands against resolved composition locations
+-- | Runs @docker-compose@ commands against resolved composition locations.
 -- See usage docs for more info. Tries to find a @dockmaster.yml@ file based on
--- the initial path argument
-dockmaster :: FilePath -> Bool -> T.Text -> [T.Text] -> Sh ()
+-- the initial path argument.
+dockmaster :: FilePath -- ^ Composition
+           -> Bool     -- ^ Local-only flag
+           -> T.Text   -- ^ Command
+           -> [T.Text] -- ^ Opts/args for Command
+           -> Sh ()
 dockmaster path local command args = do
   eWd <- getWorkDir path
   either dmcError dmExec eWd where

--- a/src/Dockmaster.hs
+++ b/src/Dockmaster.hs
@@ -6,10 +6,15 @@ Maintainer  : sam.chong.tay@gmail.com
 Stability   : experimental
 Portability : POSIX
 -}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 module Dockmaster
   (
+  -- * Runtime execution
+    dockmaster
   -- * dockmaster.yml
-    module Dockmaster.Types
+  , module Dockmaster.Types
   , module Dockmaster.Parser
   , module Dockmaster.Compose
   -- * config.yml
@@ -22,3 +27,30 @@ import Dockmaster.Parser
 import Dockmaster.Compose
 import Dockmaster.Config.Types
 import Dockmaster.Config.Parser
+
+import Shelly
+import Prelude hiding (FilePath)
+import Control.Monad (forM_)
+import qualified Data.Text as T
+default (T.Text)
+
+-- | Runs @docker-compose@ commands against resolved composition locations
+-- See usage docs for more info. Tries to find a @dockmaster.yml@ file based on
+-- the initial path argument
+dockmaster :: FilePath -> Bool -> T.Text -> [T.Text] -> Sh ()
+dockmaster path local command args = do
+  eWd <- getWorkDir path
+  either dmcError dmExec eWd where
+    dmcError WorkDirNotFound     = errorExit "Could not resolve dockmaster working directory."
+    dmcError (DecodingError err) = echo_err "Failed to parse dm configuration." >> errorExit err
+    dmExec wd = sub $ do
+      cd wd
+      dmYml <- dockmasterYml
+      case dmYml of
+        Left err    -> echo_err "Failed to parse dockmaster.yml." >> errorExit err
+        Right dmYml -> do
+          prepareEnv dmYml
+          let hookwrap = hookWrap' dmYml command $ dockercompose dmYml $ command : args
+              targets = map targetName $ dmTargets dmYml -- just grabbing machine name
+          if local then hookwrap else
+            forM_ targets $ \m -> dockermachine m hookwrap

--- a/src/Dockmaster/Parser.hs
+++ b/src/Dockmaster/Parser.hs
@@ -76,8 +76,8 @@ hookWrap :: T.Text -> Sh () -> Sh ()
 hookWrap dcCmd action = do
   dmYml <- dockmasterYml
   either
-    errorExit                            -- Exit on dockmaster.yml parsing failure
-    (\cfg -> hookWrap' cfg dcCmd action) -- Otherwise execute hooks & docker-compose
+    errorExit -- Exit on dockmaster.yml parsing failure
+    (\cfg -> sub $ prepareEnv cfg >> hookWrap' cfg dcCmd action) -- Otherwise execute hooks & action
     dmYml
 
 -- | Same thing as 'hookWrap' but accepts 'Dockmaster' config to execute against.
@@ -102,7 +102,7 @@ execHook (File txt)  = do
       else txt
   bash_ file []
 -- Execute "shell" hook type
-execHook (Shell txt) = unless (T.null txt) $ do
+execHook (Shell txt) = unless (T.null txt) $ escaping False $ do
   let (shCmd:shArgs) = T.words txt
   run_ (fromText shCmd) shArgs
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,11 +26,11 @@ nonExistingComposition :: FilePath
 nonExistingComposition = fromText "test/fixtures/compositions/NONEXISTENT"
 
 cleanup :: IO ()
-cleanup = shelly $ verbosely $ do
+cleanup = shelly $ silently $ do
   rm_rf $ robComposition </> "output"
 
 startup :: IO ()
-startup = shelly $ verbosely $ do
+startup = shelly $ silently $ do
   cd robComposition
   rm_rf "output"
   mkdir_p "output"
@@ -61,7 +61,7 @@ main = hspec $
       invalidWD `shouldBe` (Left WorkDirNotFound)
 
   describe "Environment interaction" $ do
-    txt <- runIO $ shelly $ verbosely $ errExit True $ do
+    txt <- runIO $ shelly $ silently $ errExit False $ do
       cd robComposition
       hookWrap "num" $ return ()
       readfile "output/favnum.txt"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,7 +44,7 @@ main = hspec $ do
     it "should resolve existing compositions" $ do
       validWD `shouldBe` (Right existingComposition)
     it "should fail appropriately" $ do
-      invalidWD `shouldBe` workDirNotFound
+      invalidWD `shouldBe` (Left WorkDirNotFound)
 
   describe "Environment interaction" $ do
     it "should successfully execute locally" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -19,14 +19,28 @@ validFiles = ls $ fromText "test/fixtures/valid"
 invalidFiles :: Sh [FilePath]
 invalidFiles = ls $ fromText "test/fixtures/invalid"
 
-existingComposition :: FilePath
-existingComposition = fromText "test/fixtures/compositions/exists"
+robComposition :: FilePath
+robComposition = fromText "test/fixtures/compositions/rob_example"
 
 nonExistingComposition :: FilePath
 nonExistingComposition = fromText "test/fixtures/compositions/NONEXISTENT"
 
+cleanup :: IO ()
+cleanup = shelly $ verbosely $ do
+  rm_rf $ robComposition </> "output"
+
+startup :: IO ()
+startup = shelly $ verbosely $ do
+  cd robComposition
+  rm_rf "output"
+  mkdir_p "output"
+  touchfile $ "output" </> "favnum.txt"
+
 main :: IO ()
-main = hspec $ do
+main = hspec $
+      beforeAll_ startup
+    . afterAll_ cleanup
+  $ do
 
   describe "Parsing dockmaster.yml files" $ do
     validFiles   <- runIO $ shelly $ validFiles >>= mapM parseYml 
@@ -39,19 +53,17 @@ main = hspec $ do
         file `shouldSatisfy` isLeft
 
   describe "Relative workdir resolution" $ do
-    validWD   <- runIO $ shelly $ silently $ getWorkDir' baseConfig existingComposition
+    validWD   <- runIO $ shelly $ silently $ getWorkDir' baseConfig robComposition
     invalidWD <- runIO $ shelly $ silently $ getWorkDir' baseConfig nonExistingComposition
     it "should resolve existing compositions" $ do
-      validWD `shouldBe` (Right existingComposition)
+      validWD `shouldBe` (Right robComposition)
     it "should fail appropriately" $ do
       invalidWD `shouldBe` (Left WorkDirNotFound)
 
   describe "Environment interaction" $ do
-    it "should successfully execute locally" $ do
-      pendingWith "SAM needs to add --local flag so we can test dm"
+    txt <- runIO $ shelly $ verbosely $ errExit True $ do
+      cd robComposition
+      hookWrap "num" $ return ()
+      readfile "output/favnum.txt"
     it "can propogate environment variables" $ do
-      pendingWith "SAM needs to add --local flag so we can test dm"
-
--- After adding --local flag and testing dm execution,
--- we can then test if env variables were written to output dir correctly,
--- and then do an hspec cleanup via "afterAll_"
+      txt `shouldBe` "favorite number is 1\n"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -62,8 +62,7 @@ main = hspec $
 
   describe "Environment interaction" $ do
     txt <- runIO $ shelly $ silently $ errExit False $ do
-      cd robComposition
-      hookWrap "num" $ return ()
-      readfile "output/favnum.txt"
+      dockmaster robComposition True "num" []
+      readfile $ robComposition </> "output/favnum.txt"
     it "can propogate environment variables" $ do
       txt `shouldBe` "favorite number is 1\n"

--- a/test/fixtures/compositions/rob_example/dockmaster.yml
+++ b/test/fixtures/compositions/rob_example/dockmaster.yml
@@ -8,8 +8,8 @@ commands:
   num:
     run_compose: false
     pre_hooks:
-      - shell: mkdir test/output
-      - shell: echo "robs favorite number is $ROBS_FAVORITE_NUM" > test/output/favnum.txt
+      - shell: mkdir -p output
+      - shell: echo "favorite number is $ROBS_FAVORITE_NUM" > output/favnum.txt
   push:
     help: My help text
     run_compose: false


### PR DESCRIPTION
Adds

- `--local` flag option. Name is slightly misleading, as it's not guaranteed to run locally, but rather doesn't set its own docker machine env variables; so it leaves them untouched if you are already connected to an external machine or not. This allows you to basically run dockmaster *without* the targets functionality.

- test for proper envvar propagation across hooks

- simplifies travis build to leverage stack and just use single GHC version (at least in the meantime, until `make tests` is completed)